### PR TITLE
Adding word-wrap support

### DIFF
--- a/src/highlightjs-line-numbers.js
+++ b/src/highlightjs-line-numbers.js
@@ -49,8 +49,9 @@
 			$('.hljs-line').each(function(i) {
 			  l += (i + 1) + '\n';
 			  //add a empty line if word wrap is detected (if div's height if > than the line-height)
-			  if(Math.round(parseInt($(this).height())/parseInt($(this).css('line-height'))) > 1){
-			    l += '\n';
+			  var height = Math.round(parseInt($(this).height())/parseInt($(this).css('line-height')));
+			  if( height > 1){
+				l += '\n'.repeat(height-1);
 			  }
 			});
 			$('.hljs-line-numbers').remove();

--- a/src/highlightjs-line-numbers.js
+++ b/src/highlightjs-line-numbers.js
@@ -22,26 +22,38 @@
 
 			for (var i in blocks) {
 				if (blocks.hasOwnProperty(i)) {
-					lineNumbersBlock(blocks[i]);
+					lineNumbersBlock(blocks[i], true);
 				}
 			}
+      
+		$( window ).resize(function() {
+			for (var i in blocks) {
+				if (blocks.hasOwnProperty(i)) {
+					lineNumbersBlock(blocks[i], false);
+				}
+			}
+		});
 		} catch (e) {
 			console.error('LineNumbers error: ', e);
 		}
 	}
 
-	function lineNumbersBlock (element) {
+	//Add a second parameter to know if triggered by resizing
+	function lineNumbersBlock (element, resize) {
 		if (typeof element !== 'object') return;
 
 		var parent = element.parentNode;
-		var lines = getCountLines(parent.textContent);
-
+		var lines = getCountLines(element, resize);
 		if (lines > 1) {
 			var l = '';
-			for (var i = 0; i < lines; i++) {
-				l += (i + 1) + '\n';
-			}
-
+			$('.hljs-line').each(function(i) {
+			  l += (i + 1) + '\n';
+			  //add a empty line if word wrap is detected (if div's height if > than the line-height)
+			  if(Math.round(parseInt($(this).height())/parseInt($(this).css('line-height'))) > 1){
+			    l += '\n';
+			  }
+			});
+			$('.hljs-line-numbers').remove();
 			var linesPanel = document.createElement('code');
 			linesPanel.className = 'hljs hljs-line-numbers';
 			linesPanel.style.float = 'left';
@@ -51,17 +63,26 @@
 		}
 	}
 
-	function getCountLines(text) {
+	function getCountLines(el, resize) {
+  	var text = el.innerHTML;
 		if (text.length === 0) return 0;
 
 		var regExp = /\r\n|\r|\n/g;
 		var lines = text.match(regExp);
 		lines = lines ? lines.length : 0;
-
 		if (!text[text.length - 1].match(regExp)) {
 			lines += 1;
 		}
-
+		// Don't wrap in div if resize, we have already it
+		if(resize === true){
+			//wrap each line in a div
+			var textLines = text.split(regExp);
+			var textResult = "";
+			textLines.forEach(function(element) {
+				textResult += "<div class='hljs-line'>"+element+"</div>\n";
+			});
+			el.innerHTML = textResult;
+		}
 		return lines;
 	}
 }(window));


### PR DESCRIPTION
Hi,

I'm trying to add the wrapping funciton to avoid lines without line-numbers

You can see the result here : 
http://jsfiddle.net/sLLwtwbL/2/

When resizing the window, the gutter is updated.

It resolves the defect #4 and #13 

Please add the following style in your css sheet:

`.hljs-line{
  display: inline;
}`
