### PR TITLE
Fix empty line problem

### DIFF
--- a/src/highlightjs-line-numbers.js
+++ b/src/highlightjs-line-numbers.js
@@ -107,7 +107,12 @@
 
 	function getLines(text) {
 		if (text.length === 0) return [];
-		return text.split(/\r\n|\r|\n/g);
+		var _lines = text.split(/\r\n|\r|\n/g);
+		// if last line contains only carriage return remove it
+		if (_lines[_lines.length-1].trim() === '') {
+			_lines.pop();
+		}
+		return _lines;
 	}
 
 }(window, document));


### PR DESCRIPTION
I've noticed sometimes there is a problem with additional empty line (which doesn't exist on the source code). Example from Jekyll where I use highligth.js with line-numbers:
![screen shot 2017-12-17 at 12 31 08](https://user-images.githubusercontent.com/3254609/34079078-3eebffa6-e326-11e7-818e-8ed76700a7f8.png)

This PR fix the problem.