### PR TITLE
feat: add function to process innerHTML instead and return value (#37)

### DIFF
--- a/src/highlightjs-line-numbers.js
+++ b/src/highlightjs-line-numbers.js
@@ -14,6 +14,7 @@
     if (w.hljs) {
         w.hljs.initLineNumbersOnLoad = initLineNumbersOnLoad;
         w.hljs.lineNumbersBlock = lineNumbersBlock;
+        w.hljs.lineNumbersValue = lineNumbersValue;
 
         addStyles();
     } else {
@@ -76,6 +77,25 @@
 
             element.innerHTML = addLineNumbersBlockFor(element.innerHTML, firstLineIndex);
         });
+    }
+
+    function lineNumbersValue (value, options) {
+        if (typeof value !== 'string') return;
+
+        // define options or set default
+        options = options || {
+            singleLine: false
+        };
+
+        var element = document.createElement('code')
+        element.innerHTML = value
+
+        // convert options
+        var firstLineIndex = !!options.singleLine ? 0 : 1;
+
+        duplicateMultilineNodes(element);
+
+        return addLineNumbersBlockFor(element.innerHTML, firstLineIndex);
     }
 
     function addLineNumbersBlockFor (inputHtml, firstLineIndex) {


### PR DESCRIPTION
Add a new function `lineNumbersValue` to take in a string of html, usually it's the returned value of `hljs.highlight()`, and add line number to the markup. 

Also change the function run synchronously compared to `lineNumbersBlock` because `setTimeout` makes it difficult to use the returned value.