### PR TITLE
Fix copy / paste behavior when using Firefox or Edge [DOM based] (#51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ $(document).ready(function() {
 If your needs cool style, add styles by taste:
 ```css
 /* for block of numbers */
-.hljs-ln td.hljs-ln-numbers {
+.hljs-ln-numbers {
     -webkit-touch-callout: none;
     -webkit-user-select: none;
     -khtml-user-select: none;
@@ -70,7 +70,7 @@ If your needs cool style, add styles by taste:
 }
 
 /* for block of code */
-.hljs-ln td.hljs-ln-code {
+.hljs-ln-code {
     padding-left: 10px;
 }
 ```
@@ -95,5 +95,19 @@ hljs.initLineNumbersOnLoad({
 hljs.lineNumbersBlock(myCodeBlock, myOptions);
 ```
 
+## CSS selectors
+
+You may need to select some lines of code after rendering. For instance, you may want
+to highlight a range of lines, selected by users, by changing their background color.
+The CSS selectors below can be used to perform these selection operations.
+
+CSS selector                             |  description
+-----------------------------------------|-----------------------
+`.hljs-ln-line`                          | Select all lines, including line numbers
+`.hljs-ln-numbers`                       | Select all line numbers, excluding lines of code
+`.hljs-ln-code`                          | Select all lines of code, excluding line numbers
+`.hljs-ln-line[data-line-number="i"]`    | Select the ith line, including line number
+`.hljs-ln-numbers[data-line-number="i"]` | Select the ith line number, excluding the line of code
+`.hljs-ln-code[data-line-number="i"]`    | Select the ith line of code, excluding the line number
 ---
 &copy; 2018 Yauheni Pakala | MIT License


### PR DESCRIPTION
I took some time trying to fix the annoying copy / paste behavior observed when using Firefox or Edge browsers. As explained in issue #51, blank lines are inserted in text editors after each pasted line of code, which is pretty annoying. 

Based on my understanding, this is due to different behaviors among browsers when copying
text from a multi-column based layout wrapped into a HTML `pre` element.

After numerous tryouts (notably using CSS tables instead of plain HTML ones), the only solution I found ensuring same copy/paste behavior for all browsers is the following. So instead of wrapping line numbers and code in a single `table` element, use the following approach instead:

1. render the lines number in a `table` with single column
2. render the lines of code in a `div`
3. wrap these in a `div` and make the table `float left`
4. adjust the left margin of the code `div` once inserted in the dom

With this approach, the annoying copy / paste behavior with Firefox and Edge goes away while obtaining the exact same rendering as before. 

The only drawback I see with these changes is that they may break custom user scripts selecting `hljs-ln-*` element as the html layout has been slightly modified. Nevertheless, I have also improved the way to select line elements and documented it, so custom user scripts will not be difficult to fix.
