### PR TITLE
Code: Exposure of Synchronous Lines

### DIFF
--- a/src/highlightjs-line-numbers.js
+++ b/src/highlightjs-line-numbers.js
@@ -15,6 +15,7 @@
         w.hljs.initLineNumbersOnLoad = initLineNumbersOnLoad;
         w.hljs.lineNumbersBlock = lineNumbersBlock;
         w.hljs.lineNumbersValue = lineNumbersValue;
+        w.hljs.lineNumbersInternal = lineNumbersInternal;
 
         addStyles();
     } else {


### PR DESCRIPTION
As the title says, I want to expose `lineNumbersInternal` as it represents the synchronous version of `lineNumbersBlock`. I believe there are valid use cases whereby the line-by-line mutation on the DOM should happen synchronously. The `dist` file needs to be updated accordingly.